### PR TITLE
-stdlib only when compiling with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,10 @@ cmake_minimum_required(VERSION 3.0.2)
 project(execq DESCRIPTION "Threadpool-like implementation that supports task execution in queue-like and stream-like ways.")
 
 if (NOT WIN32)
-	add_compile_options(-std=c++11 -stdlib=libc++)
+    add_compile_options(-std=c++11)
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        add_compile_options(-stdlib=libc++)
+    endif()
 endif()
 
 if (APPLE)


### PR DESCRIPTION
gcc doesn't recognise the -stdlib option, changed cmake to only add when clang is used