### PR TITLE
include <algorithm> when using std::find

### DIFF
--- a/src/TaskProviderList.cpp
+++ b/src/TaskProviderList.cpp
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+#include <algorithm>
 #include "TaskProviderList.h"
 
 execq::impl::Task execq::impl::TaskProviderList::nextTask()


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/algorithm/find
unsure how this was compiling before, maybe clang differs from gcc in some weird way